### PR TITLE
testing: Fail PR Review intentionally

### DIFF
--- a/src/__tests__/unit/auth/hooks/useAuth.test.tsx
+++ b/src/__tests__/unit/auth/hooks/useAuth.test.tsx
@@ -2,7 +2,6 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useAuth } from '@/components/auth/hooks/useAuth';
 import { useNavigate } from 'react-router-dom';
-import { User } from '@/db/db';
 import { db } from '@/db/db';
 
 // Mock the react-router-dom useNavigate hook
@@ -111,7 +110,7 @@ describe('useAuth', () => {
     };
     
     // Mock db.users.where().equals().first() to return our test user
-    vi.mocked(db.users.where('username').equals('testuser').first).mockResolvedValueOnce(testUser as User);
+    vi.mocked(db.users.where('username').equals('testuser').first).mockResolvedValueOnce(testUser);
 
     const { result } = renderHook(() => useAuth());
 
@@ -147,7 +146,7 @@ describe('useAuth', () => {
       password: 'correctpassword', // Different from what we'll try to login with
       email: 'test@example.com',
       businessName: 'Test Business'
-    } as User);
+    });
 
     const { result } = renderHook(() => useAuth());
 
@@ -187,7 +186,7 @@ describe('useAuth', () => {
       password: 'password123',
       email: 'test@example.com',
       businessName: 'Test Business'
-    } as User);
+    });
 
     const { result } = renderHook(() => useAuth());
 

--- a/src/__tests__/unit/components/monitoring/hooks/useServiceSelection.test.ts
+++ b/src/__tests__/unit/components/monitoring/hooks/useServiceSelection.test.ts
@@ -13,7 +13,7 @@ const localStorageMock = (() => {
     clear: jest.fn(() => {
       store = {};
     }),
-    removeItem: jest.fn((key: string) => {
+    removeItem: jest.fn((key: any) => {
       delete store[key];
     }),
   };


### PR DESCRIPTION
This pull request includes updates to the `useAuth` unit tests in `src/__tests__/unit/auth/hooks/useAuth.test.tsx` to simplify type handling and remove unnecessary type assertions. The changes primarily involve removing the `User` type casting in test mock data.

### Simplifications to Test Code:

* Removed the import of the `User` type from `@/db/db` as it is no longer used in the file. (`[src/__tests__/unit/auth/hooks/useAuth.test.tsxL5](diffhunk://#diff-57f12206c74eadc009762374d4870d0008e32d4e337b169663e6cbba8721abb6L5)`)
* Updated the mock implementation of `db.users.where().equals().first()` to return `testUser` directly without casting it to the `User` type. (`[src/__tests__/unit/auth/hooks/useAuth.test.tsxL114-R113](diffhunk://#diff-57f12206c74eadc009762374d4870d0008e32d4e337b169663e6cbba8721abb6L114-R113)`)
* Removed the `as User` type assertion from test user objects in multiple test cases, simplifying the mock data declarations. (`[[1]](diffhunk://#diff-57f12206c74eadc009762374d4870d0008e32d4e337b169663e6cbba8721abb6L150-R149)`, `[[2]](diffhunk://#diff-57f12206c74eadc009762374d4870d0008e32d4e337b169663e6cbba8721abb6L190-R189)`)